### PR TITLE
Add 2 simple test cases

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[report]
+show_missing = True

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nosetests -v --with-coverage --cover-package=sunriset

--- a/test.py
+++ b/test.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python
+
+import datetime
+import unittest
+
+import sunriset
+
+class TestSunriset(unittest.TestCase):
+    def test_to_pandas(self):
+        """Test conversion to the pandas data frame."""
+        lat = 34.0522
+        long = -118.2437
+        local_tz = -8
+
+        number_of_years = 1
+        start_date = datetime.date(2019, 1, 1)
+
+        df = sunriset.to_pandas(start_date, lat, long, local_tz, number_of_years)
+
+        self.assertEqual(len(df.index), 365)
+
+    def test_set_noon(self):
+        lat = 34.0522
+        long = -118.2437
+        local_tz = -8
+        start_date = datetime.date(2019, 1, 1)
+
+        rise, sset, noon = sunriset.sunrise_set_noon(start_date, lat, long, local_tz, tz_adjust=0)
+
+        self.assertEqual((rise, sset, noon),
+                         (datetime.timedelta(seconds=25116, microseconds=873548),
+                          datetime.timedelta(seconds=60871, microseconds=790164),
+                          datetime.timedelta(seconds=42994, microseconds=331856)))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Added 2 test cases to encaurage Brian to continue :)

Here is how to run tests:

```
$ ./run-tests.sh
test_set_noon (test.TestSunriset) ... ok
Test conversion to the pandas data frame. ... ok

Name                   Stmts   Miss  Cover   Missing
----------------------------------------------------
sunriset/__init__.py     115     44    62%   28, 119-170
sunriset/calc.py         120     12    90%   21-25, 38, 49, 279, 309, 316-330
----------------------------------------------------
TOTAL                    235     56    76%
----------------------------------------------------------------------
Ran 2 tests in 0.488s

OK
```

Signed-off-by: Ed Bartosh <bartosh@gmail.com>